### PR TITLE
Adding pillow to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
         'torch',
         'transformers',
         'scipy',
-        'tqdm'
+        'tqdm',
+        'pillow',
     ],
 
     classifiers=[


### PR DESCRIPTION
Doing a pip install and running the sample showed me that PIL wasn't included. Adding pillow so that it is.